### PR TITLE
Fix #1 paginación falla por culpa del type coercion

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -49,8 +49,8 @@ async function show(req, res) {
   const episodes = await si.searchByUserAndByPage({
     user: sourceMap[req.query.source || 'hs'],
     term: showName,
-    p: (req.query.page || 0) + 1,
-    n: (req.query.rpp || 20) * 3,
+    p: +(req.query.page || 0) + 1,
+    n: +(req.query.rpp || 20) * 3,
     filter: 2
   });
   const groupedByEp = groupBy(


### PR DESCRIPTION
La expresión `(page || 0) + 1` está dando como resultado "11" en vez de 2.